### PR TITLE
Updated react version and moved to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "raf": "^2.0.4"
   },
   "peerDependencies": {
-    "react": "^0.12.2"
+    "react": ">= 0.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "homepage": "https://github.com/saebekassebil/react-counter",
   "dependencies": {
     "ease-component": "^1.0.0",
-    "raf": "^2.0.4",
-    "react": "^0.12.2"
+    "raf": "^2.0.4"
+  },
+  "peerDependencies": {
+    "react": "^0.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "raf": "^2.0.4"
   },
   "peerDependencies": {
-    "react": "^0.13.1"
+    "react": "^0.12.2"
   }
 }


### PR DESCRIPTION
When using react already in a project, modules should have react in peerDependencies so that it doesn’t get included twice and uses the already included instance. Also updated React version, don’t know if you want that anyway decided to send a PR ;)
